### PR TITLE
Fixing undefined variable error

### DIFF
--- a/EditNotify.hooks.php
+++ b/EditNotify.hooks.php
@@ -802,7 +802,7 @@ class EditNotifyHooks {
 			}
 
 			if ( $categories ) {
-				foreach ( $categories as $category => $title) {
+				foreach ( $categories as $category => $catTitle) {
 					$categoryUserArray = array();
 					foreach ( $wgEditNotifyAlerts as $categoryAlert ) {
 						$handleCategoryAlert = false;

--- a/EditNotify.hooks.php
+++ b/EditNotify.hooks.php
@@ -802,7 +802,7 @@ class EditNotifyHooks {
 			}
 
 			if ( $categories ) {
-				foreach ( $categories as $category ) {
+				foreach ( $categories as $category => $title) {
 					$categoryUserArray = array();
 					foreach ( $wgEditNotifyAlerts as $categoryAlert ) {
 						$handleCategoryAlert = false;

--- a/EditNotify.hooks.php
+++ b/EditNotify.hooks.php
@@ -803,7 +803,7 @@ class EditNotifyHooks {
 
 			if ( $categories ) {
 				foreach ( $categories as $category ) {
-
+					$categoryUserArray = array();
 					foreach ( $wgEditNotifyAlerts as $categoryAlert ) {
 						$handleCategoryAlert = false;
 

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,6 @@
 	"require": {
 		"composer/installers": "~1.0"
 	},
-	"autoload": {
-		"files": [
-			
-		]
-	},
 	"require-dev": {
 		"jakub-onderka/php-parallel-lint": "0.9",
 		"mediawiki/mediawiki-codesniffer": "0.12",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+	"name": "mediawiki/edit-notify",
+	"type": "mediawiki-extension",
+	"description": "Extension for page creation or editing notification",
+	"require": {
+		"composer/installers": "~1.0"
+	},
+	"autoload": {
+		"files": [
+			"EditNotify.php"
+		]
+	},
+	"require-dev": {
+		"jakub-onderka/php-parallel-lint": "0.9",
+		"mediawiki/mediawiki-codesniffer": "0.12",
+		"phpunit/phpunit": "4.8.*"
+	},
+	"scripts": {
+		"test": [
+			"parallel-lint . --exclude vendor",
+			"phpunit",
+			"phpcs -p -s -n"
+		]
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	},
 	"autoload": {
 		"files": [
-			"EditNotify.php"
+			
 		]
 	},
 	"require-dev": {

--- a/i18n/de-formal.json
+++ b/i18n/de-formal.json
@@ -7,5 +7,5 @@
   },
   "editnotify-email-body-message": "Eine Bearbeitung wurde auf Seite \"$1\" vorgenommen. Sie bekommen diese Benachrichtigung, weil Sie diese Aktivität in \"$2\" beobachten.",
   "editnotify-email-body-message-page-create": "Seite \"$1\" wurde erstellt. Sie bekommen diese Benachrichtigung, weil Sie diese Aktivität in \"$2\" beim Seitenerstellen beobachten.",
-  "editnotify-email-body-message-template": "Wert von \"$1\" wurde von \"$2\" zu \"$3\" geändert, im Template \"$4\" auf der Seite \"$5\". Sie bekommst diese Benachrichtigung, weil Sie diese Aktivität in \"$6\" beobachten."
+  "editnotify-email-body-message-template": "Wert von \"$1\" wurde von \"$2\" zu \"$3\" geändert, im Template \"$4\" auf der Seite \"$5\". Sie bekommen diese Benachrichtigung, weil Sie diese Aktivität in \"$6\" beobachten."
 }

--- a/i18n/de-formal.json
+++ b/i18n/de-formal.json
@@ -1,0 +1,11 @@
+{
+  "@metadata": {
+    "authors": [
+      "Markus Glaser"
+
+    ]
+  },
+  "editnotify-email-body-message": "Eine Bearbeitung wurde auf Seite \"$1\" vorgenommen. Sie bekommen diese Benachrichtigung, weil Sie diese Aktivität in \"$2\" beobachten.",
+  "editnotify-email-body-message-page-create": "Seite \"$1\" wurde erstellt. Sie bekommen diese Benachrichtigung, weil Sie diese Aktivität in \"$2\" beim Seitenerstellen beobachten.",
+  "editnotify-email-body-message-template": "Wert von \"$1\" wurde von \"$2\" zu \"$3\" geändert, im Template \"$4\" auf der Seite \"$5\". Sie bekommst diese Benachrichtigung, weil Sie diese Aktivität in \"$6\" beobachten."
+}

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -5,12 +5,12 @@
 
     ]
   },
-  "editnotify-desc": "Erweiterung für eine Benachrichtigung über Seitenerstellung oder -bearbeitung",
+  "editnotify-desc": "Erweiterung für Benachrichtigungen zu Seitenerstellungen oder -bearbeitungen",
   "editnotify-page-edit-label": "Änderungen sehen",
   "editnotify-title-message": "Die Seite wurde geändert",
   "editnotify-title-message-page-create": "Die Seite wurde bearbeitet",
   "editnotify-flyout-message": "Benachrichtigung über eine Bearbeitung",
-  "editnotify-flyout-message-page-create": "Benachrichtigung über eine Seitenerstellng",
+  "editnotify-flyout-message-page-create": "Benachrichtigung über eine Seitenerstellung",
   "editnotify-primary-message": "Seite ansehen:",
   "editnotify-email-subject-message": "Die Seite \"$2\" wurde verändert",
   "editnotify-email-subject-message-page-create": "Die Seite \"$2\" wurde erstellt",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1,0 +1,31 @@
+{
+  "@metadata": {
+    "authors": [
+      "Markus Glaser"
+
+    ]
+  },
+  "editnotify-desc": "Erweiterung für eine Benachrichtigung über Seitenerstellung oder -bearbeitung",
+  "editnotify-page-edit-label": "Änderungen sehen",
+  "editnotify-title-message": "Die Seite wurde geändert",
+  "editnotify-title-message-page-create": "Die Seite wurde bearbeitet",
+  "editnotify-flyout-message": "Benachrichtigung über eine Bearbeitung",
+  "editnotify-flyout-message-page-create": "Benachrichtigung über eine Seitenerstellng",
+  "editnotify-primary-message": "Seite ansehen:",
+  "editnotify-email-subject-message": "Die Seite \"$2\" wurde verändert",
+  "editnotify-email-subject-message-page-create": "Die Seite \"$2\" wurde erstellt",
+  "editnotify-email-subject-message-template": "Seite \"$2\": der Wert von \"$3\" wurde zu \"$4\" geändert",
+  "editnotify-email-body-message": "Eine Bearbeitung wurde auf Seite \"$1\" vorgenommen. Du bekommst diese Benachrichtigung, weil du diese Aktivität in \"$2\" beobachtest.",
+  "editnotify-email-body-message-page-create": "Seite \"$1\" wurde erstellt. Du bekommst diese Benachrichtigung, weil du diese Aktivität in \"$2\" beim Seitenerstellen beobachtest.",
+  "editnotify-email-body-message-template": "Wert von \"$1\" wurde von \"$2\" zu \"$3\" geändert, im Template \"$4\" auf der Seite \"$5\". Du bekommst diese Benachrichtigung, weil du diese Aktivität in \"$6\" beobachtest.",
+  "notification-header-edit-notify-page-create": "Seite \"$3\" wurde erstellt",
+  "notification-header-edit-notify": "Seite \"$3\" wurde geändert",
+  "notification-header-edit-notify-namespace": "Seite \"$3\" wurde geändert",
+  "notification-header-edit-notify-category": "Seite \"$3\" wurde geändert",
+  "notification-header-edit-notify-template": "Wert von \"$3\" wurde im Template \"$6\" auf Seite \"$7\" von \"$4\" zu \"$5\" geändert",
+  "notification-header-edit-notify-template-namespace": "Wert von \"$3\" wurde im Template \"$6\" auf Seite \"$7\" von \"$4\" zu \"$5\" geändert",
+  "notification-header-edit-notify-template-category": "Wert von \"$3\" wurde im Template \"$6\" auf Seite \"$7\" von \"$4\" zu \"$5\" geändert",
+  "notification-header-edit-notify-template-value":"Wert von \"$3\" wurde im Template \"$6\" auf Seite \"$7\" von \"$4\" zu \"$5\" geändert",
+  "notification-header-edit-notify-template-value-namespace": "Wert von \"$3\" wurde im Template \"$6\" auf Seite \"$7\" von \"$4\" zu \"$5\" geändert",
+  "notification-header-edit-notify-template-value-category": "Wert von \"$3\" wurde im Template \"$6\" auf Seite \"$7\" von \"$4\" zu \"$5\" geändert"
+}


### PR DESCRIPTION
If there is more than one item in $categories, this would lead to an
undefined variable error for $categoryUserArray, since this variable
is unset at the end of each loop. A simple solution is to set it to
an empty array at the beginning of the loop. This fixes the notice
and does not affect the code in any other way. $categoryUserArray is
set to an empty array in line 753.